### PR TITLE
Ajuste nome do pacote no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Este pacote PHP permite validar se um CNPJ é válido  de acordo com as novas re
 Você pode instalar o pacote via Composer:
 
 ```bash
-composer require dtgfranca/cnpj-validator
+composer require dtgfranca/validador-novo-cnpj
  ```
 
 


### PR DESCRIPTION
Muda o nome do pacote de acordo com o definido no composer.json, pois com o que está no README não é possível instalar o pacote